### PR TITLE
Workaround for issue #692.

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="css/styles.css">
       
     <script src="js/angular.min.js"></script>
-    <script src="http://rawgithub.com/PascalPrecht/bower-angular-translate/master/angular-translate.min.js"></script>
+    <script src="https://rawgithub.com/PascalPrecht/bower-angular-translate/master/angular-translate.min.js"></script>
     <script src="js/docs-setup.js"></script>
     <script src="js/docs.js"></script>
     <script>


### PR DESCRIPTION
Pull request for this workaround intended to fix the [issue #692](https://github.com/angular-translate/angular-translate/issues/692). Tested under latest chrome (37.0.2062.102 m) + [https everywhere extension](https://www.eff.org/https-everywhere) and latest firefox (31.0) and the same extension. The example code now works as expected under this browser/extension combination.
